### PR TITLE
Add `funding.json` with OP retro verification

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,5 @@
+{
+  "opRetro": {
+    "projectId": "0x80393c05d524b7a6f7a78b0c141eadf0759642ae8d7e718134318cd2d73d5464"
+  }
+}

--- a/packages/contracts-bedrock/test/kontrol/funding.json
+++ b/packages/contracts-bedrock/test/kontrol/funding.json
@@ -1,0 +1,5 @@
+{
+  "opRetro": {
+    "projectId": "0x80393c05d524b7a6f7a78b0c141eadf0759642ae8d7e718134318cd2d73d5464"
+  }
+}


### PR DESCRIPTION
Adds a `funding.json` file with the following content:
```
{
  "opRetro": {
    "projectId": "0x80393c05d524b7a6f7a78b0c141eadf0759642ae8d7e718134318cd2d73d5464"
  }
}
```

I wasn't sure if we're verifying the repo or https://github.com/runtimeverification/_audits_Ethereum-optimism_pausability/tree/feature/rv-compute/packages/contracts-bedrock/test/kontrol specifically, so I added `funding.json` to both. 